### PR TITLE
REL-1232567- updated caat environment watch documentation

### DIFF
--- a/docs/analytics/caat_environment_watch_setup.md
+++ b/docs/analytics/caat_environment_watch_setup.md
@@ -29,15 +29,17 @@ For other Other integrations, refer to the [Environment Watch Install other Inte
 ### Installation Steps
 
 1.  Copy the CAAT EW bundle to your server and unzip it
-2.  Copy the following files from the EW bundle to the CAAT installer directory:
+2.  Copy the following files from the CAAT EW bundle to the CAAT installer directory:
     - `opentelemetry-javaagent.jar`
     - `startup.cmd`
     - `replace_startup.bat`
 3.  Replace `response-file.properties` with your master copy
-5.  Open PowerShell as an administrator
-6.  Run `.\Install.cmd`
-7.  Once the installation is complete, start **Relativity Analytics Engine** and verify the page is loading
-8.  Open Kibana and search for `service.name: "relsvr_caat"` in the `metrics-*` data view to confirm telemetry is being collected
+4.  Ensure no analytics jobs are currently running, then stop the **Relativity Analytics Engine** service
+5.  Stop the **Relativity Environment Watch** service before starting installation
+6.  Open PowerShell as an administrator
+7.  Run `.\Install.cmd`
+8.  Once the installation is complete, start the **Relativity Analytics Engine** and **Relativity Environment Watch** services and verify the engine is active
+9.  Open Kibana and search for `service.name: "relsvr_caat"` in the `metrics-*` data view to confirm telemetry is being collected
 
 
 ## What's updated
@@ -45,7 +47,7 @@ For other Other integrations, refer to the [Environment Watch Install other Inte
 - The Startup.cmd file is updated to include the OpenTelemetry Java Agent. This references the `opentelemetry-javaagent.jar` file, which is used to instrument the CAAT service for telemetry data collection.
 - Check for these lines within `startup.cmd`:
     ```
-    -javaagent:C:\\CAAT\\bin\\opentelemetry-javaagent.jar 
+    -javaagent:..bin\opentelemetry-javaagent.jar 
     -Dotel.service.name="relsvr.caat" 
     -Dotel.metrics.exporter=otlp 
     -Dotel.exporter.otlp.endpoint="http://localhost:4318" 
@@ -58,4 +60,3 @@ For other Other integrations, refer to the [Environment Watch Install other Inte
 1. **Check Application Logs:** On startup, the agent logs its initialization. Look for lines mentioning `opentelemetry-javaagent` in the CAAT logs.
 2. **Verify Telemetry Export:** Confirm that traces and metrics are being sent to your configured backend (e.g., OpenTelemetry Collector, Jaeger, Azure Monitor).
 3. **Check Service Name:** Ensure the service appears as `Relativity Analytics Engine` (or your configured name) in your observability backend.
-4. **Disable to Compare:** Temporarily remove the `-javaagent` flag and confirm that telemetry stops, verifying the agent is responsible for the data.

--- a/docs/analytics/caat_environment_watch_setup.md
+++ b/docs/analytics/caat_environment_watch_setup.md
@@ -20,13 +20,24 @@ For other Other integrations, refer to the [Environment Watch Install other Inte
 
 ## How to install/update CAAT
 
-1.  Copy CAAT Bundle to your server
-2.  Unzip the folder
-3.  Replace response-file.properties with master copy
-4.  Open Powershell as an administrator
-5.  Run `.\Install.cmd`
-6.  Once the installation is done, start **Relativity Analytics Engine** and check if the page is loading.
-7.  Open ElasticSearch and search for service.name: “relsvr_caat” in metrics-* data view
+### Prerequisites
+
+- Existing CAAT(4.7.11.A11) installer package
+- CAAT EW bundle (contains `opentelemetry-javaagent.jar`, `startup.cmd`, and `replace_startup.bat`)
+- Administrative access to the server
+
+### Installation Steps
+
+1.  Copy the CAAT EW bundle to your server and unzip it
+2.  Copy the following files from the EW bundle to the CAAT installer directory:
+    - `opentelemetry-javaagent.jar`
+    - `startup.cmd`
+    - `replace_startup.bat`
+3.  Replace `response-file.properties` with your master copy
+5.  Open PowerShell as an administrator
+6.  Run `.\Install.cmd`
+7.  Once the installation is complete, start **Relativity Analytics Engine** and verify the page is loading
+8.  Open Kibana and search for `service.name: "relsvr_caat"` in the `metrics-*` data view to confirm telemetry is being collected
 
 
 ## What's updated
@@ -39,11 +50,12 @@ For other Other integrations, refer to the [Environment Watch Install other Inte
     -Dotel.metrics.exporter=otlp 
     -Dotel.exporter.otlp.endpoint="http://localhost:4318" 
     -Dotel.instrumentation.runtime-metrics.enabled=true
+    -Dotel.instrumentation.java-util-logging.enabled=false
     ```
 
 ## How to verify the changes
 
 1. **Check Application Logs:** On startup, the agent logs its initialization. Look for lines mentioning `opentelemetry-javaagent` in the CAAT logs.
 2. **Verify Telemetry Export:** Confirm that traces and metrics are being sent to your configured backend (e.g., OpenTelemetry Collector, Jaeger, Azure Monitor).
-3. **Check Service Name:** Ensure the service appears as `caat-analytics-engine` (or your configured name) in your observability backend.
+3. **Check Service Name:** Ensure the service appears as `Relativity Analytics Engine` (or your configured name) in your observability backend.
 4. **Disable to Compare:** Temporarily remove the `-javaagent` flag and confirm that telemetry stops, verifying the agent is responsible for the data.


### PR DESCRIPTION
This pull request updates the CAAT Environment Watch setup documentation to clarify prerequisites, installation steps, and verification procedures. The changes make the installation instructions more explicit and improve the accuracy of the verification steps.

**Documentation improvements:**

* Expanded the installation instructions to include a prerequisites section, detailed steps for copying and replacing files, and clarified the verification process for telemetry collection.

**Configuration and verification updates:**

* Updated the recommended Java agent configuration to explicitly disable Java Util Logging instrumentation.
* Corrected the expected service name in observability backends from `caat-analytics-engine` to `Relativity Analytics Engine` for consistency with the application.

<img width="1277" height="739" alt="image" src="https://github.com/user-attachments/assets/67c35702-7d4f-421c-b011-a4e8c4d72636" />
<img width="1271" height="686" alt="image" src="https://github.com/user-attachments/assets/ab87d2a0-eba7-4009-bcb8-6fd658482a32" />


