### PR TITLE
REL-1284788: updated caat documentation

### DIFF
--- a/elastic-stack-setup/elastic-stack-setup-02-environment-watch/ew-03-extensibility-configuration/ew-extensibility-configuration-02-caat.md
+++ b/elastic-stack-setup/elastic-stack-setup-02-environment-watch/ew-03-extensibility-configuration/ew-extensibility-configuration-02-caat.md
@@ -22,15 +22,13 @@ For other Other integrations, refer to the [Environment Watch Install other Inte
 
 ### Prerequisites
 
-- Existing CAAT(4.7.11.A11) installer package
-- CAAT EW bundle (contains `opentelemetry-javaagent.jar`, `startup.cmd`, and `replace_startup.bat`)
+- Existing CAAT(5.1.4.A1) installer package
 - Administrative access to the server
 
 ### Installation Steps
 
 1.  Copy the CAAT EW bundle to your server and unzip it
 2.  Copy the following files from the CAAT EW bundle to the CAAT installer directory:
-    - `opentelemetry-javaagent.jar`
     - `startup.cmd`
     - `replace_startup.bat`
 3.  Replace `response-file.properties` with your master copy
@@ -42,18 +40,28 @@ For other Other integrations, refer to the [Environment Watch Install other Inte
 9.  Open Kibana and search for `service.name: "relsvr_caat"` in the `metrics-*` data view to confirm telemetry is being collected
 
 
-## What's updated
-
-- The Startup.cmd file is updated to include the OpenTelemetry Java Agent. This references the `opentelemetry-javaagent.jar` file, which is used to instrument the CAAT service for telemetry data collection.
-- Check for these lines within `startup.cmd`:
+## CAAT Instrumentation Configuration
+ 
+**Important**
+ 
+- CAAT instrumentation is **disabled by default** starting with this update.
+- Customers using Environment Watch (EW) must **manually enable instrumentation** after applying the patch.
+ 
+**Steps to Enable Instrumentation**
+ 
+1. Navigate to the CAAT/bin directory.
+2. Open the startup.cmd file.    
+3. Add the following lines towards the end of the JVM options section (before the final -jar entry):
     ```
-    -javaagent:..bin\opentelemetry-javaagent.jar 
-    -Dotel.service.name="relsvr.caat" 
-    -Dotel.metrics.exporter=otlp 
-    -Dotel.exporter.otlp.endpoint="http://localhost:4318" 
+    -javaagent:..bin\opentelemetry-javaagent.jar
+    -Dotel.service.name="relsvr.caat"
+    -Dotel.metrics.exporter=otlp
+    -Dotel.exporter.otlp.endpoint="http://localhost:4318"
     -Dotel.instrumentation.runtime-metrics.enabled=true
     -Dotel.instrumentation.java-util-logging.enabled=false
     ```
+4. Save the file.
+5. Restart the Analytics Service to apply the change
 
 ## How to verify the changes
 

--- a/elastic-stack-setup/elastic-stack-setup-02-environment-watch/ew-03-extensibility-configuration/ew-extensibility-configuration-02-caat.md
+++ b/elastic-stack-setup/elastic-stack-setup-02-environment-watch/ew-03-extensibility-configuration/ew-extensibility-configuration-02-caat.md
@@ -23,48 +23,40 @@ For other Other integrations, refer to the [Environment Watch Install other Inte
 ### Prerequisites
 
 - Existing CAAT(5.1.4.A1) installer package
+- CAAT EW bundle (contains `startup.cmd`)
 - Administrative access to the server
 
 ### Installation Steps
 
-1.  Copy the CAAT EW bundle to your server and unzip it
-2.  Copy the following files from the CAAT EW bundle to the CAAT installer directory:
+1.  Install/upgrade CAAT latest installer.If this has already been completed, skip this step.
+2.  Ensure no analytics jobs are currently running, then stop the **Relativity Analytics Engine** service
+3.  Stop the **Relativity Environment Watch** service in analytics server.
+4.  Copy and replace the following file from the CAAT EW bundle to the bin folder CAAT installer directory:    
     - `startup.cmd`
-    - `replace_startup.bat`
-3.  Replace `response-file.properties` with your master copy
-4.  Ensure no analytics jobs are currently running, then stop the **Relativity Analytics Engine** service
-5.  Stop the **Relativity Environment Watch** service before starting installation
-6.  Open PowerShell as an administrator
-7.  Run `.\Install.cmd`
-8.  Once the installation is complete, start the **Relativity Analytics Engine** and **Relativity Environment Watch** services and verify the engine is active
-9.  Open Kibana and search for `service.name: "relsvr_caat"` in the `metrics-*` data view to confirm telemetry is being collected
+5.  Once the copying is complete, start the **Relativity Analytics Engine** and **Relativity Environment Watch** services and verify the engine is active
+6.  Open Kibana and search for `service.name: "relsvr_caat"` in the `metrics-*` data view to confirm telemetry is being collected
 
 
-## CAAT Instrumentation Configuration
- 
-**Important**
- 
-- CAAT instrumentation is **disabled by default** starting with this update.
-- Customers using Environment Watch (EW) must **manually enable instrumentation** after applying the patch.
- 
-**Steps to Enable Instrumentation**
- 
-1. Navigate to the CAAT/bin directory.
-2. Open the startup.cmd file.    
-3. Add the following lines towards the end of the JVM options section (before the final -jar entry):
+## What's updated
+
+- The Startup.cmd file is updated to include the OpenTelemetry Java Agent. This references the `opentelemetry-javaagent.jar` file, which is used to instrument the CAAT service for telemetry data collection.
+- Check for these lines within `startup.cmd`:
     ```
-    -javaagent:..bin\opentelemetry-javaagent.jar
-    -Dotel.service.name="relsvr.caat"
-    -Dotel.metrics.exporter=otlp
-    -Dotel.exporter.otlp.endpoint="http://localhost:4318"
+    -javaagent:..bin\opentelemetry-javaagent.jar 
+    -Dotel.service.name="relsvr.caat" 
+    -Dotel.metrics.exporter=otlp 
+    -Dotel.exporter.otlp.endpoint="http://localhost:4318" 
     -Dotel.instrumentation.runtime-metrics.enabled=true
     -Dotel.instrumentation.java-util-logging.enabled=false
     ```
-4. Save the file.
-5. Restart the Analytics Service to apply the change
 
 ## How to verify the changes
 
 1. **Check Application Logs:** On startup, the agent logs its initialization. Look for lines mentioning `opentelemetry-javaagent` in the CAAT logs.
 2. **Verify Telemetry Export:** Confirm that traces and metrics are being sent to your configured backend (e.g., OpenTelemetry Collector, Jaeger, Azure Monitor).
 3. **Check Service Name:** Ensure the service appears as `Relativity Analytics Engine` (or your configured name) in your observability backend.
+
+## Important
+
+CAAT instrumentation is disabled by default starting with this update.
+Customers using Environment Watch (EW) can manually enable instrumentation after applying the patch.

--- a/elastic-stack-setup/elastic-stack-setup-02-environment-watch/ew-03-extensibility-configuration/ew-extensibility-configuration-02-caat.md
+++ b/elastic-stack-setup/elastic-stack-setup-02-environment-watch/ew-03-extensibility-configuration/ew-extensibility-configuration-02-caat.md
@@ -28,13 +28,13 @@ For other Other integrations, refer to the [Environment Watch Install other Inte
 
 ### Installation Steps
 
-1.  Install/upgrade CAAT latest installer.If this has already been completed, skip this step.
+1.  Install or upgrade the CAAT 5.1.4.A1 installer. If this has already been completed, skip this step.
 2.  Ensure no analytics jobs are currently running, then stop the **Relativity Analytics Engine** service
-3.  Stop the **Relativity Environment Watch** service in analytics server.
+3.  Stop the **Relativity Environment Watch** service on the analytics server.
 4.  Copy and replace the following file from the CAAT EW bundle into the `bin` directory of the installed CAAT application (not the `bin` directory inside the extracted CAAT installer package):    
     - `startup.cmd`
 5.  Once the copying is complete, start the **Relativity Analytics Engine** and **Relativity Environment Watch** services and verify the engine is active
-6.  Open Kibana and search for `service.name: "relsvr_caat"` in the `metrics-*` data view to confirm telemetry is being collected
+6.  Open Kibana and search for `service.name: "relsvr.caat"` in the `metrics-*` data view to confirm telemetry is being collected
 
 
 ## What's updated

--- a/elastic-stack-setup/elastic-stack-setup-02-environment-watch/ew-03-extensibility-configuration/ew-extensibility-configuration-02-caat.md
+++ b/elastic-stack-setup/elastic-stack-setup-02-environment-watch/ew-03-extensibility-configuration/ew-extensibility-configuration-02-caat.md
@@ -31,7 +31,7 @@ For other Other integrations, refer to the [Environment Watch Install other Inte
 1.  Install/upgrade CAAT latest installer.If this has already been completed, skip this step.
 2.  Ensure no analytics jobs are currently running, then stop the **Relativity Analytics Engine** service
 3.  Stop the **Relativity Environment Watch** service in analytics server.
-4.  Copy and replace the following file from the CAAT EW bundle to the bin folder CAAT installer directory:    
+4.  Copy and replace the following file from the CAAT EW bundle into the `bin` directory of the installed CAAT application (not the `bin` directory inside the extracted CAAT installer package):    
     - `startup.cmd`
 5.  Once the copying is complete, start the **Relativity Analytics Engine** and **Relativity Environment Watch** services and verify the engine is active
 6.  Open Kibana and search for `service.name: "relsvr_caat"` in the `metrics-*` data view to confirm telemetry is being collected


### PR DESCRIPTION
This pull request updates the documentation for configuring CAAT instrumentation with Environment Watch (EW). The main changes clarify the prerequisites, update the required CAAT version, and provide new instructions for manually enabling OpenTelemetry instrumentation, which is now disabled by default.

**Updated prerequisites and installation steps:**

- Updated the required CAAT installer package version from `4.7.11.A11` to `5.1.4.A1`, and removed the requirement to copy `opentelemetry-javaagent.jar` during installation.

**Instrumentation configuration and enablement:**

- Added a new section explaining that CAAT instrumentation is now disabled by default and must be manually enabled by customers after patching.
- Provided step-by-step instructions for enabling instrumentation in `startup.cmd`, including editing JVM options, saving changes, and restarting the Analytics Service. [[1]](diffhunk://#diff-899aa5f1d30e862d97f3b8b80e71a68287afb34abb182d5e86668d3fd06c2094L45-R54) [[2]](diffhunk://#diff-899aa5f1d30e862d97f3b8b80e71a68287afb34abb182d5e86668d3fd06c2094R63-R64)