### PR TITLE
REL-1270408: Added optional to add "monitoring_user" role for custom user

### DIFF
--- a/elastic-stack-setup/elastic-stack-setup-02-environment-watch/ew-02-relativity-alerts.md
+++ b/elastic-stack-setup/elastic-stack-setup-02-environment-watch/ew-02-relativity-alerts.md
@@ -78,7 +78,7 @@ To create a Kibana user and assign the custom Kibana role:
 	- **Username**: A unique login name (e.g., `alerts_dashboard_user`).<br/>
 	- **Password**: Set a strong password.<br/>
 	- **Full name / Email address**: Optional but recommended.<br/>
-5. Under **Roles**, search for and assign the `relativity_dashboard_user` role.
+5. Under **Roles**, search for and assign the `relativity_dashboard_user` role. Optionally, also assign the `monitoring_user` to enable access to Stack Monitoring.
 6. Click **Create user** to save.  
 ![](../../resources/custom_kibana_role.png)
 


### PR DESCRIPTION
Added optional to add "monitoring_user" role for custom user

To access to stack monitoring links with custom user, we have to add "monitoring_user" role
- Cluster Overview
- Elastic Overview
- Kibana Overview

<img width="250" height="155" alt="image" src="https://github.com/user-attachments/assets/2f9a2a41-0d0c-4ba2-8d8e-774c65093cef" />

above links are part of SQL dashboard navigations.

