### PR TITLE
REL-1284788: ew caat bundle changes

### DIFF
--- a/elastic-stack-setup/elastic-stack-setup-02-environment-watch/ew-03-extensibility-configuration/ew-extensibility-configuration-02-caat.md
+++ b/elastic-stack-setup/elastic-stack-setup-02-environment-watch/ew-03-extensibility-configuration/ew-extensibility-configuration-02-caat.md
@@ -22,29 +22,24 @@ For other Other integrations, refer to the [Environment Watch Install other Inte
 
 ### Prerequisites
 
-- Existing CAAT(4.7.11.A11) installer package
-- CAAT EW bundle (contains `opentelemetry-javaagent.jar`, `startup.cmd`, and `replace_startup.bat`)
+- Existing CAAT(5.1.4.A1) installer package
+- CAAT EW bundle (contains `startup.cmd`)
 - Administrative access to the server
 
 ### Installation Steps
 
-1.  Copy the CAAT EW bundle to your server and unzip it
-2.  Copy the following files from the CAAT EW bundle to the CAAT installer directory:
-    - `opentelemetry-javaagent.jar`
+1.  Install or upgrade the CAAT 5.1.4.A1 installer. If this has already been completed, skip this step.
+2.  Ensure no analytics jobs are currently running, then stop the **Relativity Analytics Engine** service
+3.  Stop the **Relativity Environment Watch** service on the analytics server.
+4.  Copy and replace the following file from the CAAT EW bundle into the `bin` directory of the installed CAAT application (not the `bin` directory inside the extracted CAAT installer package):    
     - `startup.cmd`
-    - `replace_startup.bat`
-3.  Replace `response-file.properties` with your master copy
-4.  Ensure no analytics jobs are currently running, then stop the **Relativity Analytics Engine** service
-5.  Stop the **Relativity Environment Watch** service before starting installation
-6.  Open PowerShell as an administrator
-7.  Run `.\Install.cmd`
-8.  Once the installation is complete, start the **Relativity Analytics Engine** and **Relativity Environment Watch** services and verify the engine is active
-9.  Open Kibana and search for `service.name: "relsvr_caat"` in the `metrics-*` data view to confirm telemetry is being collected
+5.  Once the copying is complete, start the **Relativity Analytics Engine** and **Relativity Environment Watch** services and verify the engine is active
+6.  Open Kibana and search for `service.name: "relsvr.caat"` in the `metrics-*` data view to confirm telemetry is being collected
 
 
 ## What's updated
 
-- The Startup.cmd file is updated to include the OpenTelemetry Java Agent. This references the `opentelemetry-javaagent.jar` file, which is used to instrument the CAAT service for telemetry data collection.
+- The Startup.cmd file is updated to include the OpenTelemetry Java Agent. This references the `opentelemetry-javaagent.jar` file (this will come with CAAT installer package), which is used to instrument the CAAT service for telemetry data collection.
 - Check for these lines within `startup.cmd`:
     ```
     -javaagent:..bin\opentelemetry-javaagent.jar 

--- a/elastic-stack-setup/elastic-stack-setup-02-environment-watch/ew-03-extensibility-configuration/ew-extensibility-configuration-02-caat.md
+++ b/elastic-stack-setup/elastic-stack-setup-02-environment-watch/ew-03-extensibility-configuration/ew-extensibility-configuration-02-caat.md
@@ -22,7 +22,7 @@ For other Other integrations, refer to the [Environment Watch Install other Inte
 
 ### Prerequisites
 
-- Existing CAAT(5.1.4.A1) installer package
+- CAAT (5.1.4.A1) installer package
 - CAAT EW bundle (contains `startup.cmd`)
 - Administrative access to the server
 

--- a/elastic-stack-setup/elastic-stack-setup-02-environment-watch/ew-03-extensibility-configuration/ew-extensibility-configuration-02-caat.md
+++ b/elastic-stack-setup/elastic-stack-setup-02-environment-watch/ew-03-extensibility-configuration/ew-extensibility-configuration-02-caat.md
@@ -39,7 +39,7 @@ For other Other integrations, refer to the [Environment Watch Install other Inte
 
 ## What's updated
 
-- The Startup.cmd file is updated to include the OpenTelemetry Java Agent. This references the `opentelemetry-javaagent.jar` file (this will come with CAAT installer package), which is used to instrument the CAAT service for telemetry data collection.
+- The `startup.cmd` file is updated to include the OpenTelemetry Java Agent. It references `opentelemetry-javaagent.jar`, which is provided by the CAAT installer package (not the CAAT EW bundle), to instrument the CAAT service for telemetry data collection.
 - Check for these lines within `startup.cmd`:
     ```
     -javaagent:..bin\opentelemetry-javaagent.jar 


### PR DESCRIPTION
This pull request updates the CAAT Environment Watch extensibility configuration documentation to reflect the new installation process for CAAT version 5.1.4.A1. The steps have been streamlined to remove references to files no longer included in the EW bundle and to clarify the correct installation procedure.

**Documentation updates for CAAT 5.1.4.A1:**

* Updated prerequisites to require the CAAT 5.1.4.A1 installer package and clarified that the EW bundle now only contains `startup.cmd`
* Revised installation steps to:
  - Specify stopping services before copying files,
  - Remove instructions for copying `opentelemetry-javaagent.jar` and `replace_startup.bat` (these are now handled by the installer),
  - Clarify that `startup.cmd` should be placed in the installed application's `bin` directory, not the installer package directory,
  - Remove unnecessary steps involving PowerShell and `Install.cmd`
* Updated verification instructions to use the correct service name (`relsvr.caat`) for telemetry checks in Kibana
* Clarified that the OpenTelemetry Java Agent JAR now comes with the CAAT installer package, not the EW bundle