### PR TITLE
REL-1299616: Fix remaining broken links in troubleshooting docs

### DIFF
--- a/elastic-stack-setup/troubleshooting/monitoring-agent-and-otel-collector.md
+++ b/elastic-stack-setup/troubleshooting/monitoring-agent-and-otel-collector.md
@@ -36,9 +36,9 @@ First, ensure that the core Elastic Stack components (Elasticsearch, Kibana, and
     A JSON response with version details indicates success.
 
 4. If a service is not running, refer to its specific troubleshooting guide:
-    - [Elasticsearch Troubleshooting](elasticsearch.md)
-    - [Kibana Troubleshooting](kibana.md)
-    - [APM Server Troubleshooting](apm-server.md)
+    - [Elasticsearch Troubleshooting](https://help.relativity.com/Server2025/Content/Elasticstack/Elasticsearch_Troubleshooting.htm)
+    - [Kibana Troubleshooting](https://help.relativity.com/Server2025/Content/Elasticstack/Kibana_Troubleshooting.htm)
+    - [APM Server Troubleshooting](https://help.relativity.com/Server2025/Content/Elasticstack/APM_Server_Troubleshooting.htm)
 
 
 - For port-related issues, see the [Pre-requisite Troubleshooting](pre-requisite-troubleshooting.md) guide.
@@ -231,7 +231,7 @@ If the above steps do not resolve the issue, verify the following access and con
 
 ### Relativity Service Account Verification
 
-For service account requirements and troubleshooting, see [Environment_Watch_Installer](../elastic-stack-setup-02-environment-watch/elastic-stack-setup-02-environment-watch.md)
+For service account requirements and troubleshooting, see [Environment_Watch_Installer](../elastic-stack-setup-02-environment-watch/ew-01-install-monitoring-agents.md)
 
 
 ## Installer and Service Errors
@@ -265,5 +265,5 @@ This section covers issues related to the Environment Watch installer and the un
 
 
 For additional troubleshooting, refer to the main documentation:  
-[Environment Watch Installer](../elastic-stack-setup-01-installation.md)
+[Environment Watch Installer](../elastic-stack-setup-02-environment-watch/ew-01-install-monitoring-agents.md)
 

--- a/elastic-stack-setup/troubleshooting/relativity-server-cli.md
+++ b/elastic-stack-setup/troubleshooting/relativity-server-cli.md
@@ -28,12 +28,12 @@ The Elastic APM integration package must be added and configured in Kibana befor
     1. Login to Kibana and navigate to **Management** > **Integrations**.
     2. Search for "Elastic APM" in the search bar.
     3. Check if "Elastic APM" appears under **Installed integrations**.
-    4. If APM integration is not installed, follow the detailed setup instructions in the [Elastic APM Integration Setup Guide](../elasticsearch_setup_development.md#step-4-additional-setup-and-verification).
+    4. If APM integration is not installed, follow the detailed setup instructions in the [Elastic APM Integration Setup Guide](https://help.relativity.com/Server2025/Content/Elasticstack/Installing_Elastic_Stack.htm#additional-setup-and-verification).
 
         ![Installed_Integrations](../../resources/troubleshooting-images/installed_integrations.png)
 
 > [!NOTE]
-> If you encounter errors such as "Package not found" or installation timeouts during APM integration package installation, refer to the official [Elastic APM Integration Setup Guide](../elasticsearch_setup_development.md#elastic-apm-integration-package).
+> If you encounter errors such as "Package not found" or installation timeouts during APM integration package installation, refer to the official [Elastic APM Integration Setup Guide](https://help.relativity.com/Server2025/Content/Elasticstack/Installing_Elastic_Stack.htm#additional-setup-and-verification).
 
 To verify connectivity, always use the following format for verification commands:
 ```powershell
@@ -66,7 +66,7 @@ Expected Output:
 
 #### Self Instrumentation Data View
 
-Self-instrumentation allows you to monitor the CLI's own metrics, traces, and logs. See [Self-Instrumentation](apm-server.md#self-instrumentation) for setup and troubleshooting instructions.
+Self-instrumentation allows you to monitor the CLI's own metrics, traces, and logs. See [Self-Instrumentation](https://help.relativity.com/Server2025/Content/Elasticstack/APM_Server_Troubleshooting.htm#self-instrumentation) for setup and troubleshooting instructions.
 
 
 > Without the self-instrumentation Data View, you may not see CLI self-monitoring data in Kibana dashboards.
@@ -91,7 +91,7 @@ Kibana encryption keys must be added to `C:\elastic\kibana\config\kibana.yml` be
 [ERROR] Missing required Kibana encryption key: xpack.security.encryptionKey
 ```
 
-If you encounter encryption key validation errors or warnings in the CLI, follow the instructions in [Kibana Encryption Keys Configuration](kibana.md#5-kibana-encryption-keys-configuration).
+If you encounter encryption key validation errors or warnings in the CLI, follow the instructions in [Kibana Encryption Keys Configuration](https://help.relativity.com/Server2025/Content/Elasticstack/Kibana_Troubleshooting.htm#kibana-encryption-keys-configuration).
 
 ## Common CLI Errors
 
@@ -151,4 +151,4 @@ This section covers common errors encountered during the Environment Watch and D
     relsvr.exe setup
     ```
 
-For full setup instructions, see [Relativity_Server_CLI Setup](../relativity_server_cli_setup.md).
+For full setup instructions, see [Relativity_Server_CLI Setup](../elastic-stack-setup-02-environment-watch/elastic-stack-setup-02-environment-watch.md).


### PR DESCRIPTION
- monitoring-agent-and-otel-collector.md:
  - elasticsearch.md -> Server2025 Elasticsearch Troubleshooting URL
  - kibana.md -> Server2025 Kibana Troubleshooting URL
  - apm-server.md -> Server2025 APM Server Troubleshooting URL
  - Environment_Watch_Installer links -> ew-01-install-monitoring-agents.md (x2)

https://github.com/user-attachments/assets/efaa791f-188f-4acf-95c5-62c5e01ded2c

- relativity-server-cli.md:
   - 2 x broken links to [Elastic APM Integration Setup Guide]
   - broken link to [Self-Instrumentation]
   - broken link to [Kibana Encryption Keys Configuration]
   - broken link to [Relativity_Server_CLI Setup]

https://github.com/user-attachments/assets/56baa5f9-d3c7-4d4f-b148-7278ca159578


- https://github.com/relativitydev/server-bundle-release/blob/main/elastic-stack-setup/environment_watch_product_overview.md?plain=1 Broken images

https://github.com/user-attachments/assets/15e5be6f-12ea-49c3-bfdf-e85311b44de4
