### PR TITLE
REL-850418: Update certified Elasticsearch versions and remove broad compatibility statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This release bundle contains packages that are required to set up or upgrade two
 
 | **Requirement**   | **Relativity Server 2024 Patch 2**                                  | **Relativity Server 2025**                                  |
 | :---------------- | :------------------------------------------------------------------ | :---------------------------------------------------------- |
-| Elastic Stack     |v7.17 and above (within the v7 series) - Data Grid Audit only<br/> Server 2024 is compatible with Elasticsearch 8.x and 9.x. The following versions are officially certified for both Data Grid Audit and Environment Watch: <br/> v8.19.8, v9.1.3 <br/> <br/> <i>Note: Elasticsearch v7 reached end of vendor support on January 15, 2026. When planning an upgrade, Relativity recommends using the latest supported Elasticsearch version</i>| Server 2025 is compatible with Elasticsearch 8.x and 9.x. The following versions are officially certified for both Data Grid Audit and Environment Watch: <br/> v8.19.8, v9.1.3|
+| Elastic Stack     |v7.17 and above (within the v7 series) - Data Grid Audit only<br/> The following versions are officially certified for both Data Grid Audit and Environment Watch: <br/> v8.19.8, v9.1.3, v9.4.3 <br/> <br/> <i>Note: Elasticsearch v7 reached end of vendor support on January 15, 2026. When planning an upgrade, Relativity recommends using the latest supported Elasticsearch version</i>| The following versions are officially certified for both Data Grid Audit and Environment Watch: <br/> v8.19.8, v9.1.3, v9.4.3|
 
 **Network Ports**: Ensure required ports are open for Elastic Stack communication. [Refer to the port diagram](./elastic-stack-setup/elastic-stack-port-diagram.md) for full network configuration details.
 

--- a/elastic-stack-setup/elastic-stack-setup-03-audit.md
+++ b/elastic-stack-setup/elastic-stack-setup-03-audit.md
@@ -7,7 +7,7 @@ After installing the required Elastic components for Data Grid Audit, the integr
 
 > Please review the following important information before proceeding:
 > * **For Existing Data Grid Audit Customers:** You must be on Elasticsearch 7.17 or later the first time you run the Relativity Server CLI for Data Grid Audit against this cluster — this applies regardless of how long Data Grid Audit has been in use.
-> * Before upgrading to Elasticsearch 8.x or 9.x, the `ESIndexCreationSetting` may need to be updated. For details, refer to the [Instance setting Details](https://help.relativity.com/Server2024/Content/System_Guides/Instance_Setting_Guide/Instance_setting_descriptions.htm#ESIndexCreationSettings).
+> * Before upgrading Elasticsearch, the `ESIndexCreationSetting` may need to be updated. For details, refer to the [Instance setting Details](https://help.relativity.com/Server2024/Content/System_Guides/Instance_Setting_Guide/Instance_setting_descriptions.htm#ESIndexCreationSettings).
 > * Always verify the minimum required Elasticsearch version in your specific release bundle, as it may differ from the versions mentioned here.
 
 ### Prerequisites


### PR DESCRIPTION
## Summary

- Updated certified Elasticsearch versions to **v8.19.8, v9.1.3, v9.4.3** in the README System Requirements table for both Server 2024 and Server 2025 columns
- Removed broad \compatible with Elasticsearch 8.x and 9.x\ phrasing from both columns
- Removed \8.x or 9.x\ phrasing from the upgrade note in \lastic-stack-setup-03-audit.md\
- v7 row and EOL note left unchanged (customers on v7 are served by the existing note)

## Files Changed
- \README.md\
- \lastic-stack-setup/elastic-stack-setup-03-audit.md\

## Jira
[REL-850418](https://jira.kcura.com/browse/REL-850418)