### PR TITLE
REL-850418: Add Relativity Server 2026 EA to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ This release bundle contains packages that are required to set up or upgrade two
 
 ## System Requirements
 
-| **Requirement**   | **Relativity Server 2024 Patch 2**                                  | **Relativity Server 2025**                                  |
-| :---------------- | :------------------------------------------------------------------ | :---------------------------------------------------------- |
-| Elastic Stack     |v7.17 and above (within the v7 series) - Data Grid Audit only<br/> The following versions are officially certified for both Data Grid Audit and Environment Watch: <br/> v8.19.8, v9.1.3, v9.4.3 <br/> <br/> <i>Note: Elasticsearch v7 reached end of vendor support on January 15, 2026. When planning an upgrade, Relativity recommends using the latest supported Elasticsearch version</i>| The following versions are officially certified for both Data Grid Audit and Environment Watch: <br/> v8.19.8, v9.1.3, v9.4.3|
+| **Requirement**   | **Relativity Server 2024 Patch 2**                                  | **Relativity Server 2025**                                  | **Relativity Server 2026 EA**                               |
+| :---------------- | :------------------------------------------------------------------ | :---------------------------------------------------------- | :---------------------------------------------------------- |
+| Elastic Stack     |v7.17 and above (within the v7 series) - Data Grid Audit only<br/> The following versions are officially certified for both Data Grid Audit and Environment Watch: <br/> v8.19.8, v9.1.3, v9.4.3 <br/> <br/> <i>Note: Elasticsearch v7 reached end of vendor support on January 15, 2026. When planning an upgrade, Relativity recommends using the latest supported Elasticsearch version</i>| The following versions are officially certified for both Data Grid Audit and Environment Watch: <br/> v8.19.8, v9.1.3, v9.4.3| The following versions are officially certified for both Data Grid Audit and Environment Watch: <br/> v8.19.8, v9.1.3, v9.4.3|
 
 **Network Ports**: Ensure required ports are open for Elastic Stack communication. [Refer to the port diagram](./elastic-stack-setup/elastic-stack-port-diagram.md) for full network configuration details.
 
@@ -21,6 +21,7 @@ This release bundle contains packages that are required to set up or upgrade two
 Be sure to refer to the Environment Watch Catalog documentation that corresponds to your installed Server version:
 > - [Environment Watch Catalog - Relativity Server 2024 Patch 2+](https://help.relativity.com/Server2024/Content/Environment_Watch/Guides/Environment_Watch_Catalog.htm)
 > - [Environment Watch Catalog - Relativity Server 2025](https://help.relativity.com/Server2025/Content/Environment_Watch/Guides/Environment_Watch_Catalog.htm)
+> - [Environment Watch Catalog - Relativity Server 2026 EA](https://help.relativity.com/Server2026/Content/Environment_Watch/Guides/Environment_Watch_Catalog.htm)
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- Added **Relativity Server 2026 EA** column to the System Requirements table with certified Elasticsearch versions (v8.19.8, v9.1.3, v9.4.3)
- Added Environment Watch Catalog link for Server 2026 EA to the version-specific documentation note

<img width="675" height="473" alt="image" src="https://github.com/user-attachments/assets/de602b13-d75f-464f-9df1-5f6b986c65c1" />


## Test plan
- [x] Verify README renders correctly in GitHub
- [x] Confirm Server 2026 EA catalog link resolves: https://help.relativity.com/Server2026/Content/Environment_Watch/Guides/Environment_Watch_Catalog.htm

🤖 Generated with [Claude Code](https://claude.com/claude-code)